### PR TITLE
Set minSdkVersion to 7

### DIFF
--- a/rv-joiner-lib/build.gradle
+++ b/rv-joiner-lib/build.gradle
@@ -11,7 +11,7 @@ android {
     buildToolsVersion "23.0.2"
 
     defaultConfig {
-        minSdkVersion 10
+        minSdkVersion 7
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
As far as I can see, nothing in the library uses APIs only available on Android API >10, so I set it down to API 7 (the minimum requirement for the support library).
